### PR TITLE
Add filter option to include/exclude manifest entries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,31 @@ export default defineConfig({
 
 ### Plugin Options
 
-- `filename` (string): The name of the manifest file.
-- `publicPath` (string):  The public path to prepend to the file paths in the manifest.
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `fileName` | `string` | — | **Required.** The name of the manifest file. |
+| `publicPath` | `string` | `'/'` | The public path to prepend to the file paths in the manifest. |
+| `filter` | `(entry: ManifestEntry) => boolean` | `undefined` | Filter function to include/exclude manifest entries. Return `true` to keep the entry. |
+
+The `ManifestEntry` type:
+
+```ts
+type ManifestEntry = {
+  key: string;                  // The manifest key (e.g., "src/main.js")
+  value: Record<string, any>;   // The manifest value object
+}
+```
+
+#### Filter Example
+
+```ts
+viteManifestPlugin({
+  fileName: 'manifest.json',
+  publicPath: '/static/',
+  // Only include entry points
+  filter: (entry) => entry.value.isEntry === true,
+})
+```
 
 ## Project Structure
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,26 @@
 /**
+ * Represents a Vite manifest chunk value.
+ */
+export type ManifestValue = {
+  file: string;
+  src?: string;
+  css?: string[];
+  assets?: string[];
+  imports?: string[];
+  dynamicImports?: string[];
+  isEntry?: boolean;
+  isDynamicEntry?: boolean;
+  [key: string]: unknown;
+}
+
+/**
  * Represents a manifest entry with its key and value.
  */
 export type ManifestEntry = {
   /** The manifest key (e.g., "src/main.js") */
   key: string;
   /** The manifest value object */
-  value: Record<string, any>;
+  value: ManifestValue;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,14 @@
 /**
+ * Represents a manifest entry with its key and value.
+ */
+export type ManifestEntry = {
+  /** The manifest key (e.g., "src/main.js") */
+  key: string;
+  /** The manifest value object */
+  value: Record<string, any>;
+}
+
+/**
  * Options for modifing manifest.
  */
 export type ManifestOptions = {
@@ -6,4 +16,6 @@ export type ManifestOptions = {
   fileName: string;
   /** The public path to be append in front of asset path*/
   publicPath?: string;
+  /** Filter function to include/exclude manifest entries. Return true to keep the entry. */
+  filter?: (entry: ManifestEntry) => boolean;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -208,6 +208,101 @@ describe('modifiedManifest', () => {
         );
     });
 
+    it('should filter out entries when filter returns false', async () => {
+        const mockManifest = {
+            "main.js": { "file": "assets/main.js" },
+            "vendor.js": { "file": "assets/vendor.js" },
+            "polyfills.js": { "file": "assets/polyfills.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            filter: (entry) => entry.key !== 'polyfills.js'
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/assets/main.js" },
+                "vendor.js": { "file": "/static/assets/vendor.js" }
+            }, null, 2)
+        );
+    });
+
+    it('should keep all entries when filter always returns true', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" },
+            "vendor.js": { "file": "vendor.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            filter: () => true
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/main.js" },
+                "vendor.js": { "file": "/static/vendor.js" }
+            }, null, 2)
+        );
+    });
+
+    it('should remove all entries when filter always returns false', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" },
+            "vendor.js": { "file": "vendor.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            filter: () => false
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({}, null, 2)
+        );
+    });
+
+    it('should filter based on entry value properties', async () => {
+        const mockManifest = {
+            "main.js": { "file": "assets/main.js", "isEntry": true },
+            "vendor.js": { "file": "assets/vendor.js" },
+            "style.css": { "file": "assets/style.css", "isEntry": true }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            filter: (entry) => entry.value.isEntry === true
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/assets/main.js", "isEntry": true },
+                "style.css": { "file": "/static/assets/style.css", "isEntry": true }
+            }, null, 2)
+        );
+    });
+
     it('should handle empty manifest', async () => {
         const mockManifest = {};
         const options: ManifestOptions = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,11 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
 
     for (const key in manifest) {
       if (Object.hasOwnProperty.call(manifest, key)) {
+        if (options.filter && !options.filter({ key, value: manifest[key] })) {
+          delete manifest[key];
+          continue;
+        }
+
         const publicPath = options.publicPath ?? "/";
         const separator = publicPath.endsWith('/') ? '' : '/';
         manifest[key].file = `${publicPath}${separator}${manifest[key].file}`;


### PR DESCRIPTION
## Summary
- Add `ManifestEntry` type and `filter` option to `ManifestOptions`
- `filter: (entry: ManifestEntry) => boolean` — return `true` to keep, `false` to exclude
- Entries are filtered before path rewriting

## Test plan
- [x] Filter excludes specific entries by key
- [x] Filter keeps all entries when returning true
- [x] Filter removes all entries when returning false
- [x] Filter based on entry value properties (e.g., `isEntry`)
- [x] All 29 tests pass