### PR TITLE
Add map option to transform manifest entries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,13 +65,14 @@ export default defineConfig({
 | `fileName` | `string` | — | **Required.** The name of the manifest file. |
 | `publicPath` | `string` | `'/'` | The public path to prepend to the file paths in the manifest. |
 | `filter` | `(entry: ManifestEntry) => boolean` | `undefined` | Filter function to include/exclude manifest entries. Return `true` to keep the entry. |
+| `map` | `(entry: ManifestEntry) => ManifestEntry` | `undefined` | Transform function applied to each manifest entry after path rewriting. Can modify keys and values. |
 
 The `ManifestEntry` type:
 
 ```ts
 type ManifestEntry = {
   key: string;                  // The manifest key (e.g., "src/main.js")
-  value: Record<string, any>;   // The manifest value object
+  value: ManifestValue;         // The manifest value object
 }
 ```
 
@@ -83,6 +84,20 @@ viteManifestPlugin({
   publicPath: '/static/',
   // Only include entry points
   filter: (entry) => entry.value.isEntry === true,
+})
+```
+
+#### Map Example
+
+```ts
+viteManifestPlugin({
+  fileName: 'manifest.json',
+  publicPath: '/static/',
+  // Strip "src/" prefix from manifest keys
+  map: (entry) => ({
+    key: entry.key.replace('src/', ''),
+    value: entry.value,
+  }),
 })
 ```
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,4 +33,6 @@ export type ManifestOptions = {
   publicPath?: string;
   /** Filter function to include/exclude manifest entries. Return true to keep the entry. */
   filter?: (entry: ManifestEntry) => boolean;
+  /** Map function to transform manifest entries after path rewriting. */
+  map?: (entry: ManifestEntry) => ManifestEntry;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -70,11 +70,11 @@ describe('modifiedManifest', () => {
 
     it('should handle CSS files in manifest entries', async () => {
         const mockManifest = {
-            "main.js": { 
+            "main.js": {
                 "file": "main.js",
                 "css": ["styles.css", "theme.css"]
             },
-            "vendor.js": { 
+            "vendor.js": {
                 "file": "vendor.js",
                 "css": ["vendor.css"]
             }
@@ -91,11 +91,11 @@ describe('modifiedManifest', () => {
         expect(writeFileSync).toHaveBeenCalledWith(
             'dist/manifest.json',
             JSON.stringify({
-                "main.js": { 
+                "main.js": {
                     "file": "/assets/main.js",
                     "css": ["/assets/styles.css", "/assets/theme.css"]
                 },
-                "vendor.js": { 
+                "vendor.js": {
                     "file": "/assets/vendor.js",
                     "css": ["/assets/vendor.css"]
                 }
@@ -165,11 +165,11 @@ describe('modifiedManifest', () => {
                 "file": "index.html",
                 "css": ["main.css"]
             },
-            "main.js": { 
+            "main.js": {
                 "file": "assets/main-abc123.js",
                 "css": ["assets/main-def456.css"]
             },
-            "vendor.js": { 
+            "vendor.js": {
                 "file": "assets/vendor-789xyz.js"
             },
             "polyfills.js": {
@@ -193,11 +193,11 @@ describe('modifiedManifest', () => {
                     "file": "https://cdn.example.com/index.html",
                     "css": ["https://cdn.example.com/main.css"]
                 },
-                "main.js": { 
+                "main.js": {
                     "file": "https://cdn.example.com/assets/main-abc123.js",
                     "css": ["https://cdn.example.com/assets/main-def456.css"]
                 },
-                "vendor.js": { 
+                "vendor.js": {
                     "file": "https://cdn.example.com/assets/vendor-789xyz.js"
                 },
                 "polyfills.js": {
@@ -303,6 +303,79 @@ describe('modifiedManifest', () => {
         );
     });
 
+    it('should transform entries with map option', async () => {
+        const mockManifest = {
+            "main.js": { "file": "assets/main.js" },
+            "vendor.js": { "file": "assets/vendor.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            map: (entry) => ({
+                key: entry.key.toUpperCase(),
+                value: { ...entry.value, mapped: true }
+            })
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "MAIN.JS": { "file": "/static/assets/main.js", "mapped": true },
+                "VENDOR.JS": { "file": "/static/assets/vendor.js", "mapped": true }
+            }, null, 2)
+        );
+    });
+
+    it('should apply map after path rewriting', async () => {
+        const mockManifest = {
+            "main.js": { "file": "assets/main.js" }
+        };
+        const mapFn = vi.fn((entry) => entry);
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            map: mapFn
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(mapFn).toHaveBeenCalledWith({
+            key: 'main.js',
+            value: { file: '/static/assets/main.js' }
+        });
+    });
+
+    it('should allow map to rename keys', async () => {
+        const mockManifest = {
+            "src/main.js": { "file": "assets/main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            map: (entry) => ({
+                key: entry.key.replace('src/', ''),
+                value: entry.value
+            })
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/assets/main.js" }
+            }, null, 2)
+        );
+    });
+
     it('should handle empty manifest', async () => {
         const mockManifest = {};
         const options: ManifestOptions = {
@@ -397,7 +470,7 @@ describe('modifiedManifest', () => {
 
         expect(consoleErrorSpy).toHaveBeenCalledWith('An error occurred:', expect.any(SyntaxError));
         expect(writeFileSync).not.toHaveBeenCalled();
-        
+
         consoleErrorSpy.mockRestore();
     });
 
@@ -414,7 +487,7 @@ describe('modifiedManifest', () => {
         expect(readFile).toHaveBeenCalledWith('output/manifest.json', 'utf-8');
         expect(consoleErrorSpy).toHaveBeenCalledWith('An error occurred:', expect.any(Error));
         expect(writeFileSync).not.toHaveBeenCalled();
-        
+
         consoleErrorSpy.mockRestore();
     });
 
@@ -429,11 +502,11 @@ describe('modifiedManifest', () => {
         });
 
         await modifiedManifest('invalidPath', options);
-        
+
         expect(consoleErrorSpy).toHaveBeenCalledWith('An error occurred:', expect.any(Error));
         expect(readFile).not.toHaveBeenCalled();
         expect(writeFileSync).not.toHaveBeenCalled();
-        
+
         consoleErrorSpy.mockRestore();
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,12 +2,14 @@ import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { readFile } from 'fs/promises';
 
-import { ManifestOptions } from "./types";
+import { ManifestOptions, ManifestValue } from "./types";
 
 export const modifiedManifest = async (outputPath: string | undefined, options: ManifestOptions): Promise<void> => {
   try {
     const manifestPath = resolve(`${outputPath ?? ""}/${options.fileName}`);
     const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+
+    const result: Record<string, ManifestValue> = {};
 
     for (const key in manifest) {
       if (Object.hasOwnProperty.call(manifest, key)) {
@@ -31,10 +33,17 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
             manifest[key].assets[assetKey] = `${publicPath}${separator}${manifest[key].assets[assetKey]}`;
           }
         }
+
+        if (options.map) {
+          const mapped = options.map({ key, value: manifest[key] });
+          result[mapped.key] = mapped.value;
+        } else {
+          result[key] = manifest[key];
+        }
       }
     }
 
-    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    writeFileSync(manifestPath, JSON.stringify(result, null, 2));
   } catch (error) {
     console.error('An error occurred:', error);
     // Continue running the program


### PR DESCRIPTION
## Summary
- Add `ManifestEntry` type and `map` option to `ManifestOptions`
- `map: (entry: ManifestEntry) => ManifestEntry` — transform entries after path rewriting
- Supports renaming keys, adding properties, or modifying values

## Test plan
- [x] Map transforms entry values (adds properties)
- [x] Map is called after path rewriting
- [x] Map can rename keys
- [x] All 28 tests pass