### PR TITLE
Add seed option to merge initial entries into manifest

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ export default defineConfig({
 | `basePath` | `string` | `''` | Path prefix prepended to all manifest keys. |
 | `removeKeyHash` | `RegExp \| false` | `undefined` | RegExp to strip hashes from manifest keys. Set to `false` to explicitly disable. |
 | `serialize` | `(manifest: Record<string, ManifestValue>) => string` | `undefined` | Custom serialization function. Defaults to `JSON.stringify` with 2-space indent. |
+| `seed` | `Record<string, unknown>` | `undefined` | Initial key/value pairs merged into the manifest. Build entries take precedence over seed keys. |
 
 The `ManifestEntry` type:
 
@@ -137,6 +138,17 @@ viteManifestPlugin({
   publicPath: '/static/',
   // Output as YAML instead of JSON
   serialize: (manifest) => yaml.dump(manifest),
+})
+```
+
+#### Seed Example
+
+```ts
+viteManifestPlugin({
+  fileName: 'manifest.json',
+  publicPath: '/static/',
+  // Inject custom metadata into the manifest
+  seed: { version: '1.0.0', buildTime: new Date().toISOString() },
 })
 ```
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,4 +41,6 @@ export type ManifestOptions = {
   removeKeyHash?: RegExp | false;
   /** Custom serialization function. Defaults to JSON.stringify with 2-space indent. */
   serialize?: (manifest: Record<string, ManifestValue>) => string;
+  /** Initial key/value pairs to merge into the manifest. */
+  seed?: Record<string, unknown>;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -549,6 +549,74 @@ describe('modifiedManifest', () => {
         );
     });
 
+    it('should merge seed into manifest', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            seed: { "version": "1.0.0", "buildTime": "2024-01-01" }
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "version": "1.0.0",
+                "buildTime": "2024-01-01",
+                "main.js": { "file": "/static/main.js" }
+            }, null, 2)
+        );
+    });
+
+    it('should let manifest entries override seed keys', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            seed: { "main.js": { "custom": true } }
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/main.js" }
+            }, null, 2)
+        );
+    });
+
+    it('should use empty seed without affecting manifest', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            seed: {}
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/main.js" }
+            }, null, 2)
+        );
+    });
+
     it('should handle empty manifest', async () => {
         const mockManifest = {};
         const options: ManifestOptions = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,9 +52,11 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
       }
     }
 
+    const finalResult: Record<string, unknown> = options.seed ? { ...options.seed, ...result } : result;
+
     const output = options.serialize
-      ? options.serialize(result)
-      : JSON.stringify(result, null, 2);
+      ? options.serialize(finalResult as Record<string, ManifestValue>)
+      : JSON.stringify(finalResult, null, 2);
 
     writeFileSync(manifestPath, output);
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add `seed` option (`Record<string, any>`) to `ManifestOptions`
- Seed entries are merged into the manifest, with build entries taking precedence over seed keys

## Test plan
- [x] Seed entries are merged into manifest output
- [x] Manifest entries override conflicting seed keys
- [x] Empty seed has no effect
- [x] All 28 tests pass