### PR TITLE
Add serialize option for custom output formats

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ export default defineConfig({
 | `map` | `(entry: ManifestEntry) => ManifestEntry` | `undefined` | Transform function applied to each manifest entry after path rewriting. Can modify keys and values. |
 | `basePath` | `string` | `''` | Path prefix prepended to all manifest keys. |
 | `removeKeyHash` | `RegExp \| false` | `undefined` | RegExp to strip hashes from manifest keys. Set to `false` to explicitly disable. |
+| `serialize` | `(manifest: Record<string, ManifestValue>) => string` | `undefined` | Custom serialization function. Defaults to `JSON.stringify` with 2-space indent. |
 
 The `ManifestEntry` type:
 
@@ -123,6 +124,19 @@ viteManifestPlugin({
   publicPath: '/static/',
   // Remove 8-char hex hashes from keys: "assets/main-a1b2c3d4.js" → "assets/main.js"
   removeKeyHash: /[-][a-f0-9]{8}/gi,
+})
+```
+
+#### Serialize Example
+
+```ts
+import yaml from 'js-yaml';
+
+viteManifestPlugin({
+  fileName: 'manifest.yaml',
+  publicPath: '/static/',
+  // Output as YAML instead of JSON
+  serialize: (manifest) => yaml.dump(manifest),
 })
 ```
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,4 +39,6 @@ export type ManifestOptions = {
   basePath?: string;
   /** RegExp to remove hashes from manifest keys. Set to false to disable. Defaults to /([a-f0-9]{8}\.?)/gi. */
   removeKeyHash?: RegExp | false;
+  /** Custom serialization function. Defaults to JSON.stringify with 2-space indent. */
+  serialize?: (manifest: Record<string, ManifestValue>) => string;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -510,6 +510,45 @@ describe('modifiedManifest', () => {
         );
     });
 
+    it('should use custom serialize function', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            serialize: (manifest) => `# Custom\n${JSON.stringify(manifest)}`
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            '# Custom\n{"main.js":{"file":"/static/main.js"}}'
+        );
+    });
+
+    it('should use default JSON serialization when serialize is not provided', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/'
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('dist', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'dist/manifest.json',
+            JSON.stringify({ "main.js": { "file": "/static/main.js" } }, null, 2)
+        );
+    });
+
     it('should handle empty manifest', async () => {
         const mockManifest = {};
         const options: ManifestOptions = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,11 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
       }
     }
 
-    writeFileSync(manifestPath, JSON.stringify(result, null, 2));
+    const output = options.serialize
+      ? options.serialize(result)
+      : JSON.stringify(result, null, 2);
+
+    writeFileSync(manifestPath, output);
   } catch (error) {
     console.error('An error occurred:', error);
     // Continue running the program


### PR DESCRIPTION
## Summary
- Add `serialize` option (`(manifest) => string`) to `ManifestOptions`
- Allows custom serialization formats (YAML, TOML, minified JSON, etc.)
- Defaults to `JSON.stringify(manifest, null, 2)` when not provided

## Test plan
- [x] Custom serialize function produces custom output
- [x] Default JSON serialization unchanged when serialize omitted
- [x] All 27 tests pass