### PR TITLE
Add basePath option to prefix manifest keys

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ export default defineConfig({
 | `publicPath` | `string` | `'/'` | The public path to prepend to the file paths in the manifest. |
 | `filter` | `(entry: ManifestEntry) => boolean` | `undefined` | Filter function to include/exclude manifest entries. Return `true` to keep the entry. |
 | `map` | `(entry: ManifestEntry) => ManifestEntry` | `undefined` | Transform function applied to each manifest entry after path rewriting. Can modify keys and values. |
+| `basePath` | `string` | `''` | Path prefix prepended to all manifest keys. |
 
 The `ManifestEntry` type:
 
@@ -99,6 +100,18 @@ viteManifestPlugin({
     value: entry.value,
   }),
 })
+```
+
+#### BasePath Example
+
+```ts
+viteManifestPlugin({
+  fileName: 'manifest.json',
+  publicPath: '/static/',
+  // Prefix all keys with "dist/"
+  basePath: 'dist/',
+})
+// Result: { "dist/main.js": { "file": "/static/main.js" } }
 ```
 
 ## Project Structure

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,4 +35,6 @@ export type ManifestOptions = {
   filter?: (entry: ManifestEntry) => boolean;
   /** Map function to transform manifest entries after path rewriting. */
   map?: (entry: ManifestEntry) => ManifestEntry;
+  /** Path prefix prepended to all manifest keys. */
+  basePath?: string;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -376,6 +376,73 @@ describe('modifiedManifest', () => {
         );
     });
 
+    it('should prepend basePath to manifest keys', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" },
+            "vendor.js": { "file": "vendor.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            basePath: 'dist/'
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('output', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'output/manifest.json',
+            JSON.stringify({
+                "dist/main.js": { "file": "/static/main.js" },
+                "dist/vendor.js": { "file": "/static/vendor.js" }
+            }, null, 2)
+        );
+    });
+
+    it('should not modify keys when basePath is empty', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/',
+            basePath: ''
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('output', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'output/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/main.js" }
+            }, null, 2)
+        );
+    });
+
+    it('should not modify keys when basePath is not provided', async () => {
+        const mockManifest = {
+            "main.js": { "file": "main.js" }
+        };
+        const options: ManifestOptions = {
+            fileName: 'manifest.json',
+            publicPath: '/static/'
+        };
+
+        (readFile as any).mockResolvedValue(JSON.stringify(mockManifest));
+
+        await modifiedManifest('output', options);
+
+        expect(writeFileSync).toHaveBeenCalledWith(
+            'output/manifest.json',
+            JSON.stringify({
+                "main.js": { "file": "/static/main.js" }
+            }, null, 2)
+        );
+    });
+
     it('should handle empty manifest', async () => {
         const mockManifest = {};
         const options: ManifestOptions = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
     const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
 
     const result: Record<string, ManifestValue> = {};
+    const basePath = options.basePath ?? '';
 
     for (const key in manifest) {
       if (Object.hasOwnProperty.call(manifest, key)) {
@@ -36,9 +37,11 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
 
         if (options.map) {
           const mapped = options.map({ key, value: manifest[key] });
-          result[mapped.key] = mapped.value;
+          const newKey = basePath ? `${basePath}${mapped.key}` : mapped.key;
+          result[newKey] = mapped.value;
         } else {
-          result[key] = manifest[key];
+          const newKey = basePath ? `${basePath}${key}` : key;
+          result[newKey] = manifest[key];
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add `basePath` option (string) to `ManifestOptions`
- Prepends the basePath to all manifest keys (e.g., `"dist/main.js"` instead of `"main.js"`)
- Defaults to empty string (no prefix)

## Test plan
- [x] basePath prefixes all manifest keys
- [x] Empty basePath has no effect
- [x] Omitted basePath has no effect
- [x] All 28 tests pass