### PR TITLE
Move typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
   ],
   "author": "thanat.wongamut",
   "license": "ISC",
-  "dependencies": {
-    "typescript": "^5.5.2"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ThanatWongsamut/vite-manifest-plugin.git"
@@ -48,6 +45,7 @@
     "@vitest/coverage-v8": "3.2.4",
     "eslint": "^9.5.0",
     "tsup": "^8.1.0",
+    "typescript": "^5.5.2",
     "vite": "^5.3.1",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      typescript:
-        specifier: ^5.5.2
-        version: 5.8.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.29.0
@@ -33,6 +29,9 @@ importers:
       tsup:
         specifier: ^8.1.0
         version: 8.5.0(postcss@8.5.6)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.5.2
+        version: 5.8.3
       vite:
         specifier: ^5.3.1
         version: 5.4.19(@types/node@20.19.1)


### PR DESCRIPTION
## Summary
- Move `typescript` from `dependencies` to `devDependencies`
- TypeScript is a build-time tool, not a runtime dependency — consumers shouldn't have it installed as a transitive dep

## Test plan
- [x] `pnpm install` succeeds
- [x] All tests pass
- [x] Build succeeds