### PR TITLE
Re-export types from package entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { Plugin } from "vite"
 import { ManifestOptions } from "./types"
 import { modifiedManifest } from "./utils"
 
+export type { ManifestOptions, ManifestEntry, ManifestValue } from "./types"
+
 export const viteManifestPlugin = async (options: ManifestOptions): Promise<Plugin> => {
   const plugin: Plugin = {
     name: 'vite-manifest-plugin',


### PR DESCRIPTION
## Summary
- Re-export `ManifestOptions`, `ManifestEntry`, and `ManifestValue` types from `src/index.ts`
- Consumers can now `import type { ManifestOptions } from 'vite-manifest-plugin'` instead of reaching into internal paths

## Test plan
- [x] All tests pass
- [x] Build succeeds
- [x] `dist/index.d.ts` contains all exported types