### PR TITLE
Remove redundant delete in filter logic

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,6 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
     for (const key in manifest) {
       if (Object.hasOwnProperty.call(manifest, key)) {
         if (options.filter && !options.filter({ key, value: manifest[key] })) {
-          delete manifest[key];
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Remove unnecessary `delete manifest[key]` when filter returns false
- Filtered entries already skip the `result` object via `continue`, so mutating the original manifest is redundant

## Test plan
- [x] All 48 tests pass (including all filter tests)