### PR TITLE
Refactor: Split modifiedManifest into smaller functions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,67 @@ const prependPath = (publicPath: string, filePath: string): string => {
   return `${publicPath}${separator}${filePath}`;
 };
 
+const rewritePaths = (entry: ManifestValue, publicPath: string): void => {
+  entry.file = prependPath(publicPath, entry.file);
+
+  if (Object.hasOwnProperty.call(entry, 'css')) {
+    for (const cssKey in entry.css) {
+      entry.css![cssKey] = prependPath(publicPath, entry.css![cssKey]);
+    }
+  }
+
+  if (Object.hasOwnProperty.call(entry, 'assets')) {
+    for (const assetKey in entry.assets) {
+      entry.assets![assetKey] = prependPath(publicPath, entry.assets![assetKey]);
+    }
+  }
+};
+
+const processKey = (key: string, removeKeyHash: RegExp | false | undefined): string => {
+  if (removeKeyHash !== false && removeKeyHash) {
+    removeKeyHash.lastIndex = 0;
+    return key.replace(removeKeyHash, '');
+  }
+  return key;
+};
+
+const processManifest = (manifest: Record<string, ManifestValue>, options: ManifestOptions): Record<string, ManifestValue> => {
+  const result: Record<string, ManifestValue> = {};
+  const basePath = options.basePath ?? '';
+  const publicPath = options.publicPath ?? "/";
+
+  for (const key in manifest) {
+    if (Object.hasOwnProperty.call(manifest, key)) {
+      if (options.filter && !options.filter({ key, value: manifest[key] })) {
+        continue;
+      }
+
+      rewritePaths(manifest[key], publicPath);
+
+      const processedKey = processKey(key, options.removeKeyHash);
+
+      if (options.map) {
+        const mapped = options.map({ key: processedKey, value: manifest[key] });
+        const newKey = basePath ? `${basePath}${mapped.key}` : mapped.key;
+        result[newKey] = mapped.value;
+      } else {
+        const newKey = basePath ? `${basePath}${processedKey}` : processedKey;
+        result[newKey] = manifest[key];
+      }
+    }
+  }
+
+  return result;
+};
+
+const serializeResult = (result: Record<string, ManifestValue>, options: ManifestOptions): string => {
+  const finalResult: Record<string, unknown> = options.seed ? { ...options.seed, ...result } : result;
+
+  return options.serialize
+    ? options.serialize(finalResult as Record<string, ManifestValue>)
+    : JSON.stringify(finalResult, null, 2);
+};
+
 export const modifiedManifest = async (outputPath: string | undefined, options: ManifestOptions): Promise<void> => {
   try {
     const manifestPath = resolve(`${outputPath ?? ""}/${options.fileName}`);
@@ -20,56 +81,11 @@ export const modifiedManifest = async (outputPath: string | undefined, options: 
       return;
     }
 
-    const result: Record<string, ManifestValue> = {};
-    const basePath = options.basePath ?? '';
-    const publicPath = options.publicPath ?? "/";
-
-    for (const key in manifest) {
-      if (Object.hasOwnProperty.call(manifest, key)) {
-        if (options.filter && !options.filter({ key, value: manifest[key] })) {
-          continue;
-        }
-
-        manifest[key].file = prependPath(publicPath, manifest[key].file);
-
-        if(Object.hasOwnProperty.call(manifest[key], 'css')) {
-          for (const cssKey in manifest[key].css) {
-            manifest[key].css[cssKey] = prependPath(publicPath, manifest[key].css[cssKey]);
-          }
-        }
-
-        if(Object.hasOwnProperty.call(manifest[key], 'assets')) {
-          for (const assetKey in manifest[key].assets) {
-            manifest[key].assets[assetKey] = prependPath(publicPath, manifest[key].assets[assetKey]);
-          }
-        }
-
-        let processedKey = key;
-        if (options.removeKeyHash !== false && options.removeKeyHash) {
-          options.removeKeyHash.lastIndex = 0;
-          processedKey = key.replace(options.removeKeyHash, '');
-        }
-
-        if (options.map) {
-          const mapped = options.map({ key: processedKey, value: manifest[key] });
-          const newKey = basePath ? `${basePath}${mapped.key}` : mapped.key;
-          result[newKey] = mapped.value;
-        } else {
-          const newKey = basePath ? `${basePath}${processedKey}` : processedKey;
-          result[newKey] = manifest[key];
-        }
-      }
-    }
-
-    const finalResult: Record<string, unknown> = options.seed ? { ...options.seed, ...result } : result;
-
-    const output = options.serialize
-      ? options.serialize(finalResult as Record<string, ManifestValue>)
-      : JSON.stringify(finalResult, null, 2);
+    const result = processManifest(manifest, options);
+    const output = serializeResult(result, options);
 
     writeFileSync(manifestPath, output);
   } catch (error) {
     console.error('An error occurred:', error);
-    // Continue running the program
   }
 }


### PR DESCRIPTION
## Summary
- Extract `rewritePaths` — prepends publicPath to file, css, and assets fields
- Extract `processKey` — handles removeKeyHash regex replacement
- Extract `processManifest` — orchestrates the per-entry loop (filter, rewrite, key processing, map)
- Extract `serializeResult` — handles seed merging and serialization
- `modifiedManifest` is now a slim orchestrator: read → generate/process → write

## Test plan
- [x] All 48 existing tests pass (`vitest run`)
- [x] Lint clean (`eslint src/`)
- No behavior changes — pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)